### PR TITLE
setup.py: fix license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
     license_files=["LICENSE"],
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: Apache-2.0",
+        "License :: OSI Approved :: Apache Software License"
         "Operating System :: OS Independent",
     ],
     # Package contents control


### PR DESCRIPTION
Updated license classifier according to https://pypi.org/classifiers/. This should fix https://github.com/chipsalliance/f4pga-sdf-timing/actions/runs/3517881450/jobs/5896162201#step:11:28